### PR TITLE
🐳 migrated kfdrc dockers to d3b-bixu

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,6 @@ In this workflow, annoFuse performs standardization of StarFusion and arriba out
 
 Please refer to [annoFuse](https://github.com/d3b-center/annoFuse) R package for additional applications like putative oncogene annotations.
 
-Current version is 0.90.0, docker pull tag: `kfdrc/annofuse:0.90.0`
-
 ## Usage
 
 ### Inputs

--- a/tools/annoFuse.cwl
+++ b/tools/annoFuse.cwl
@@ -4,7 +4,7 @@ id: annoFuse
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/annofuse:0.90.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/annofuse:0.90.0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 4

--- a/tools/arriba_draw_fusion.cwl
+++ b/tools/arriba_draw_fusion.cwl
@@ -4,7 +4,7 @@ id: arriba_fusion
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/arriba:1.1.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/arriba:1.1.0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 1

--- a/tools/arriba_fusion.cwl
+++ b/tools/arriba_fusion.cwl
@@ -4,7 +4,7 @@ id: arriba_fusion
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/arriba:1.1.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/arriba:1.1.0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 8

--- a/tools/cutadapter.cwl
+++ b/tools/cutadapter.cwl
@@ -4,7 +4,7 @@ id: cutadapter
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/cutadapt:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/cutadapt:latest'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 16

--- a/tools/format_fusion_file.cwl
+++ b/tools/format_fusion_file.cwl
@@ -4,7 +4,7 @@ id: format_fusion_file
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/annofuse:0.90.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/annofuse:0.90.0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 4

--- a/tools/fusion_annotator.cwl
+++ b/tools/fusion_annotator.cwl
@@ -4,7 +4,7 @@ id: fusion_annotator
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'gaonkark/fusionanno:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/fusionanno:latest'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 4

--- a/tools/pizzly_fusion.cwl
+++ b/tools/pizzly_fusion.cwl
@@ -4,7 +4,7 @@ id: pizzly
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/pizzly:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/pizzly:latest'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 8

--- a/tools/samtools_fastq.cwl
+++ b/tools/samtools_fastq.cwl
@@ -4,7 +4,7 @@ id: bam2fastq
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 36

--- a/tools/samtools_flagstat.cwl
+++ b/tools/samtools_flagstat.cwl
@@ -4,7 +4,7 @@ id: samtools_flagstat
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 4

--- a/tools/samtools_sort.cwl
+++ b/tools/samtools_sort.cwl
@@ -4,7 +4,7 @@ id: samtools_sort
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/samtools:1.9'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 16

--- a/tools/star_align.cwl
+++ b/tools/star_align.cwl
@@ -4,7 +4,7 @@ id: star_alignReads
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/star:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/star:2.6.1d'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 16

--- a/tools/star_fusion.cwl
+++ b/tools/star_fusion.cwl
@@ -4,7 +4,7 @@ id: star_fusion
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/star-fusion:1.5.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/star-fusion:1.5.0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 16

--- a/tools/star_fusion.cwl
+++ b/tools/star_fusion.cwl
@@ -4,7 +4,7 @@ id: star_fusion
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/star-fusion:1.5.0'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/star:fusion-1.5.0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 16

--- a/tools/star_genomegenerate.cwl
+++ b/tools/star_genomegenerate.cwl
@@ -4,7 +4,7 @@ id: build_star_align_ref
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'kfdrc/star:latest'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/star:2.6.1d'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: "$(inputs.runThreadN ? inputs.runThreadN : 16)"

--- a/tools/supplemental_tar_gz.cwl
+++ b/tools/supplemental_tar_gz.cwl
@@ -4,7 +4,7 @@ id: supplemental_tar_gz
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'ubuntu:18.04'
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/ubuntu:18.04'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: 4

--- a/workflow/kfdrc-rnaseq-workflow.cwl
+++ b/workflow/kfdrc-rnaseq-workflow.cwl
@@ -363,5 +363,5 @@ sbg:categories:
 - SE
 - STAR
 sbg:links:
-- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v2.3.1'
+- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v2.4.0'
   label: github-release


### PR DESCRIPTION
## Description

This PR changes the dockerPull statements to now pull from our d3b-bixu account on SBG.
Also changed is the docker tag for STAR. The `latest` tag on kfdrc was really just `2.6.1d`.

Part of https://github.com/d3b-center/bixu-tracker/issues/846

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/769bb924-a9f2-4545-ba5f-843b81db2574/#
- [x] Ubuntu and Fusionanno update: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/67a2fc07-621f-4477-ad82-69322f30ac97/#

**Test Configuration**:
* Environment: Cavatica
* Test files: see test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
