### PR TITLE
🐛  star nameext failure

### DIFF
--- a/tools/star_align.cwl
+++ b/tools/star_align.cwl
@@ -20,7 +20,7 @@ arguments:
       --outSAMattrRGline $(inputs.outSAMattrRGline)
       --genomeDir ./$(inputs.genomeDir.nameroot.split('.')[0])/
       --readFilesIn $(inputs.readFilesIn1.path) $(inputs.readFilesIn2 ? inputs.readFilesIn2.path : '')
-      --readFilesCommand $(inputs.readFilesIn1.nameext == 'gz' ? 'zcat' : '-')
+      --readFilesCommand $(inputs.readFilesIn1.nameext == '.gz' ? 'zcat' : '-')
       --runThreadN $(inputs.runThreadN)
       --twopassMode Basic
       --outFilterMultimapNmax 20

--- a/workflow/kfdrc-rnaseq-workflow.cwl
+++ b/workflow/kfdrc-rnaseq-workflow.cwl
@@ -530,5 +530,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v3.0.0'
+- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v3.0.1'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Hotfix for the RNAseq pipeline. Bug introduced last release where the nameext was check was missing a `.`. Added it to the CWL and it appears to be working now.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-z6mwd3h0-rnaseq-analysis/tasks/20d85115-729b-4f60-89f3-247403858b9f/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
