### PR TITLE
🔧 Change default fusion name column

### DIFF
--- a/docs/D3B_ANNOFUSE.md
+++ b/docs/D3B_ANNOFUSE.md
@@ -13,8 +13,8 @@ Please refer to [annoFuse](https://github.com/d3b-center/annoFuse) R package for
 ```yaml
 inputs:
   sample_name: { type: 'string', doc: "Sample name used for file base name of all outputs" }
-  FusionGenome: { type: 'File', doc: "GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz", sbg:suggestedValue: { class: 'File', path: '5d9c8d04e4b0950cce147f94', name: 'GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz' }}
-  genome_untar_path: { type: 'string?', doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v27_CTAT_lib_Feb092018/ctat_genome_lib_build_dir" }
+  FusionGenome: { type: 'File', doc: "GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz", "sbg:suggestedValue": { class: 'File', path: '62853e7ad63f7c6d8d7ae5a8', name: 'GRCh38_v39_CTAT_lib_Mar242022.CUSTOM.tar.gz' }}
+  genome_untar_path: { type: 'string?', doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v39_CTAT_lib_Mar242022.CUSTOM" }
   rsem_expr_file: { type: 'File', doc: "gzipped rsem gene expression file" }
   arriba_output_file: { type: 'File', doc: "Output from arriba, usually extension arriba.fusions.tsv" }
   col_num: { type: 'int?', doc: "column number in file of fusion name." }
@@ -32,5 +32,5 @@ inputs:
 
 ```yaml
 outputs:
-  annofuse_filtered_fusions_tsv: {type: File, outputSource: annoFuse_filter/filtered_fusions_tsv, doc: "Filtred output of formatted and annotated Star Fusion and arriba results"}
+  annofuse_filtered_fusions_tsv: {type: File, outputSource: annoFuse_filter/filtered_fusions_tsv, doc: "Filtered output of formatted and annotated Star Fusion and arriba results"}
 ```

--- a/tools/fusion_annotator.cwl
+++ b/tools/fusion_annotator.cwl
@@ -25,8 +25,8 @@ arguments:
 inputs:
   input_fusion_file: {type: File, doc: "Fusion file formatted by format_fusion_file.cwl, likely from arriba input"}
   genome_tar: File
-  genome_untar_path: {type: ['null', string], doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v27_CTAT_lib_Feb092018/ctat_genome_lib_build_dir"}
-  col_num: {type: ['null', int], doc: "column number in file of fusion name", default: 24}
+  genome_untar_path: {type: ['null', string], doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v39_CTAT_lib_Mar242022.CUSTOM"}
+  col_num: {type: ['null', int], doc: "column number in file of fusion name, use 24 for arriba v1.1, 30 for v2", default: 30}
   output_basename: string
 
 outputs:

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -865,5 +865,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v4.2.0'
+- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v4.2.1'
   label: github-release

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -523,7 +523,7 @@ inputs:
   # annoFuse
   sample_name: {type: 'string?', doc: "Sample ID of the input reads. If not provided,\
       \ will use reads1 file basename."}
-  annofuse_col_num: {type: 'int?', doc: "column number in file of fusion name."}
+  annofuse_col_num: {type: 'int?', doc: "column number in file of fusion name.", default: 30}
   # rmats
   rmats_read_length: {type: 'int', doc: "Input read length for sample reads."}
   rmats_variable_read_length: {type: 'boolean?', doc: "Allow reads with lengths that\

--- a/workflow/kfdrc_annoFuse_wf.cwl
+++ b/workflow/kfdrc_annoFuse_wf.cwl
@@ -6,7 +6,7 @@ requirements:
 
 inputs:
   sample_name: { type: 'string', doc: "Sample name to apply. Ought to be one from some kind of clinical database" }
-  FusionGenome: { type: 'File', doc: "GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz", "sbg:suggestedValue": { class: 'File', path: '5d9c8d04e4b0950cce147f94', name: 'GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz' }}
+  FusionGenome: { type: 'File', doc: "GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz", "sbg:suggestedValue": { class: 'File', path: '62853e7ad63f7c6d8d7ae5a8', name: 'GRCh38_v39_CTAT_lib_Mar242022.CUSTOM.tar.gz' }}
   genome_untar_path: { type: 'string?', doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v39_CTAT_lib_Mar242022.CUSTOM" }
   rsem_expr_file: { type: 'File', doc: "gzipped rsem gene expression file" }
   arriba_output_file: { type: 'File', doc: "Output from arriba, usually extension arriba.fusions.tsv" }

--- a/workflow/kfdrc_annoFuse_wf.cwl
+++ b/workflow/kfdrc_annoFuse_wf.cwl
@@ -7,10 +7,10 @@ requirements:
 inputs:
   sample_name: { type: 'string', doc: "Sample name to apply. Ought to be one from some kind of clinical database" }
   FusionGenome: { type: 'File', doc: "GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz", "sbg:suggestedValue": { class: 'File', path: '5d9c8d04e4b0950cce147f94', name: 'GRCh38_v27_CTAT_lib_Feb092018.plug-n-play.tar.gz' }}
-  genome_untar_path: { type: 'string?', doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v27_CTAT_lib_Feb092018/ctat_genome_lib_build_dir" }
+  genome_untar_path: { type: 'string?', doc: "This is what the path will be when genome_tar is unpackaged", default: "GRCh38_v39_CTAT_lib_Mar242022.CUSTOM" }
   rsem_expr_file: { type: 'File', doc: "gzipped rsem gene expression file" }
   arriba_output_file: { type: 'File', doc: "Output from arriba, usually extension arriba.fusions.tsv" }
-  col_num: { type: 'int?', doc: "column number in file of fusion name." }
+  col_num: { type: 'int?', doc: "column number in file of fusion name, use 24 for arriba v1.1, 30 for v2", default: 30 }
   star_fusion_output_file: { type: 'File', doc: "Output from STAR Fusion, usually extension STAR.fusion_predictions.abridged.coding_effect.tsv" }
   output_basename: { type: 'string', doc: "String to use as basename for outputs" }
 


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Ops ran into some errant outputs from annoFuse, as the column from arriba v2.2.1 containing the fusion name is in a different position than it was in v1.1.0.
 - Changed default column from `24` to `30`
 - Updated default reference file for standalone annoFuse workflow

Fixes # https://github.com/d3b-center/bixu-tracker/issues/1737

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran updated annoFuse workflow, [old result](https://cavatica.sbgenomics.com/u/kfdrc-harmonization/sd-bhjxbdqk-rnaseq-analysis-gencode-v39/files/62fd6a8f0d345971485902b9/) has `NA` for annotation, [new result](https://cavatica.sbgenomics.com/u/kids-first-drc/kids-first-drc-rnaseq-workflow/files/63b7081d9668d812ed3016c6/) from task https://cavatica.sbgenomics.com/u/kids-first-drc/kids-first-drc-rnaseq-workflow/tasks/f2d5fbae-97cf-4ecd-8d85-06c6cedacf1d/# look correct.


**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
