### PR TITLE
🐛 Critical bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ cram_reference: { type: 'File?', secondaryFiles: [.fai], doc: "If input align is
 ```yaml
 r1_adapter: { type: 'string?', doc: "Optional input. If the input reads have already been trimmed, leave these as null. If they do need trimming, supply the adapters." }
 r2_adapter: { type: 'string?', doc: "Optional input. If the input reads have already been trimmed, leave these as null. If they do need trimming, supply the adapters." }
+min_len: { type: 'int?', doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output", default: 20 }
+quality_base: { type: 'int?', doc: "Phred scale used", default: 33 }
+quality_cutoff: {type: 'int[]?', doc: "Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled" }
+
 ```
 ### STAR:
 This section may seem overwhelming.
@@ -225,6 +229,9 @@ Kids First favors setting/overriding defaults with "arriba-heavy" specified in [
 
 - If the input reads have already been trimmed, leave these as null and cutadapt step will simple pass on the fastq files to STAR.
 - If they do need trimming, supply the adapters and the cutadapt step will trim, and pass trimmed fastqs along.
+- `min_len` if adapter is trimmed, currently set to min `20` bp. Change this as you see fit
+- `quality_base` set to phred scale `33` by default if trimming. There was a weird time when `64` was used - change if different
+- `quality_cutoff` if adapter is trimmed and you want to set a min bp quality. A single value will apply to both paired ends, 2 values will allow you to assign a different one to each (unusual)
 
 3) `wf_strand_param` is a workflow convenience param so that, if you input the following, the equivalent will propagate to the four tools that use that parameter:
 

--- a/tools/cutadapter_3.4.cwl
+++ b/tools/cutadapter_3.4.cwl
@@ -39,8 +39,8 @@ inputs:
     inputBinding: { prefix: "-m", position: 4 } }
   quality_base: { type: 'int?', doc: "Phred scale used", default: 33,
     inputBinding: { prefix: "--quality-base", position: 4 } }
-  quality_cutoff: {type: 'int?', doc: "Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled", default: 20,
-    inputBinding: { prefix: "--quality-cutoff", position: 4, itemSeparator: "," } }
+  quality_cutoff: {type: 'int[]?', doc: "Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled",
+    inputBinding: { prefix: "--quality-cutoff", position: 4, itemSeparator: ",", shellQuote: false} }
   readFilesIn1: { type: File, doc: "read1 fastq file", inputBinding: {position: 4} }
   readFilesIn2: { type: 'File?', doc: "read2 fastq file, if paired", inputBinding: {position: 4} }
   sample_name: string

--- a/tools/cutadapter_3.4.cwl
+++ b/tools/cutadapter_3.4.cwl
@@ -11,8 +11,7 @@ requirements:
     coresMin: 8
     ramMin: 16000
 
-baseCommand: [cutadapt, -j 8
-, -m 20, --quality-base=33, -q 20]
+baseCommand: [cutadapt, -j 8]
 arguments:
   - position: 1
     shellQuote: false
@@ -35,7 +34,13 @@ arguments:
 
 inputs:
   r1_adapter: { type: string, doc: "read1 adapter sequence", inputBinding: {prefix: "-a", position: 1} }
-  r2_adapter: { type: 'string?', doc: "read2 adapter sequence, if paired", inputBinding: {prefix: "-A", position: 2} }
+  r2_adapter: { type: 'string?', doc: "read2 adapter sequence, if paired", inputBinding: {prefix: "-A", position: 3} }
+  min_len: { type: 'int?', doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output", default: 20,
+    inputBinding: { prefix: "-m", position: 4 } }
+  quality_base: { type: 'int?', doc: "Phred scale used", default: 33,
+    inputBinding: { prefix: "--quality-base", position: 4 } }
+  quality_cutoff: {type: 'int?', doc: "Quality trim cutoff, see https://cutadapt.readthedocs.io/en/v3.4/guide.html#quality-trimming for how 5' 3' is handled", default: 20,
+    inputBinding: { prefix: "--quality-cutoff", position: 4, itemSeparator: "," } }
   readFilesIn1: { type: File, doc: "read1 fastq file", inputBinding: {position: 4} }
   readFilesIn2: { type: 'File?', doc: "read2 fastq file, if paired", inputBinding: {position: 4} }
   sample_name: string

--- a/tools/rmats_both_bam.cwl
+++ b/tools/rmats_both_bam.cwl
@@ -73,7 +73,7 @@ inputs:
       alternative splicing events, and calculate P value (if not --statoff).
       both: prep + post. Tool default: both
   read_length: { type: 'int', inputBinding: { position: 2, prefix: '--readLength' }, doc: "Input read length for sample reads." }
-  variable_read_length: { type: 'boolean?', inputBinding: { position: 2, prefix: '--variable-read-length' }, doc: "Allow reads with lengths that differ from --readLength to be processed. --readLength will still be used to determine IncFormLen and SkipFormLen." }
+  variable_read_length: { type: 'boolean?', inputBinding: { position: 2, prefix: '--variable-read-length' }, doc: "Allow reads with lengths that differ from --readLength to be processed. --readLength will still be used to determine IncFormLen and SkipFormLen.", default: true }
   anchor_length: { type: 'int?', inputBinding: { position: 2, prefix: '--anchorLength' }, doc: "The anchor length. Tool default: 1" }
   tophat_anchor_length: { type: 'int?', inputBinding: { position: 2, prefix: '--tophatAnchor' }, doc: "The 'anchor length' or 'overhang length' used in the aligner. At least 'anchor length' NT must be mapped to each end of a given junction. (Only if using fastq). Tool default: 6." }
   star_indicies: { type: 'Directory?', inputBinding: { position: 2, prefix: '--bi' }, doc: "The directory name of the STAR binary indices (name of the directory that contains the SA file). (Only if using fastq)" }

--- a/tools/rmats_both_bam.cwl
+++ b/tools/rmats_both_bam.cwl
@@ -94,3 +94,5 @@ outputs:
   mutually_exclusive_exons_jc: { type: 'File', outputBinding: { glob: '*.MXE.*JC.txt' } }
   retained_introns_jc: { type: 'File', outputBinding: { glob: '*.RI.*JC.txt' } }
   skipped_exons_jc: { type: 'File', outputBinding: { glob: '*.SE.*JC.txt' } }
+  temp_read_outcomes: { type: File, outputBinding: { glob: 'temp/*_read_outcomes_by_bam.txt'} }
+  summary_file: { type: File, outputBinding: { glob: '$(inputs.output_directory)/summary.txt' }}

--- a/workflow/rmats_wf.cwl
+++ b/workflow/rmats_wf.cwl
@@ -48,6 +48,7 @@ outputs:
   filtered_mutually_exclusive_exons_jc: {type: 'File', outputSource: filter_me_exons/output, doc: "Mutually exclusive exons JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
   filtered_retained_introns_jc: {type: 'File', outputSource: filter_retained_introns/output, doc: "Retained introns JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
   filtered_skipped_exons_jc: {type: 'File', outputSource: filter_skipped_exons/output, doc: "Skipped exons JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
+  unfiltered_results: { type: 'File[]', outputSource: [rmats_both_bam/alternative_3_prime_splice_sites_jc, rmats_both_bam/alternative_5_prime_splice_sites_jc, rmats_both_bam/mutually_exclusive_exons_jc, rmats_both_bam/retained_introns_jc, rmats_both_bam/skipped_exons_jc, rmats_both_bam/temp_read_outcomes, rmats_both_bam/summary_file] }
 
 steps:
   rmats_both_bam: 
@@ -66,7 +67,7 @@ steps:
       output_directory: output_basename
       threads: rmats_threads
       ram: rmats_ram
-    out: [alternative_3_prime_splice_sites_jc, alternative_5_prime_splice_sites_jc, mutually_exclusive_exons_jc, retained_introns_jc, skipped_exons_jc]
+    out: [alternative_3_prime_splice_sites_jc, alternative_5_prime_splice_sites_jc, mutually_exclusive_exons_jc, retained_introns_jc, skipped_exons_jc, temp_read_outcomes, summary_file]
   filter_alt_3_prime:
     run: ../tools/awk_junction_filtering.cwl
     in:


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

While investigating rMATS weirdness in Maris, it was discovered that read 2 (mates) was not passed properly to STAR after cutadapt if a user provided an adapter sequence. Changes overall include:
 - Fixing that bug
 - Making quality trimming optional
 - Making variable read len for rMATs default per @naqvia recommendation
 - Updates to docs

Fixes # https://github.com/d3b-center/bixu-tracker/issues/1856 and https://github.com/d3b-center/bixu-tracker/issues/1840

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] [Cutadapt single qual](https://cavatica.sbgenomics.com/u/kids-first-drc/kids-first-drc-rnaseq-workflow)
- [ ] [Cutadapt diff qual](https://cavatica.sbgenomics.com/u/kids-first-drc/kids-first-drc-rnaseq-workflow/tasks/45622c7b-da48-43b6-95c1-994e7ef34691/)
- [ ] [Mates pass fix](https://cavatica.sbgenomics.com/u/kids-first-drc/kids-first-drc-rnaseq-workflow/tasks/e7ba1bb7-95c8-4427-b67a-a52f0f17100e/), see logs to confirm mates from cutadapt passed to STAR properly

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
