### PR TITLE
🤖 Compute rMATs readlength inputs

### DIFF
--- a/tools/samtools_readlength_bam.cwl
+++ b/tools/samtools_readlength_bam.cwl
@@ -2,7 +2,11 @@ cwlVersion: v1.2
 class: CommandLineTool
 id: samtools_readlength_bam
 doc: |-
-  samtools view file.bam | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c | sort -nr -k1,1
+  Does the following:
+  - Uses samtools + head to view the first 1000000 lines of the input BAM
+  - Using the BAM's 10th column determine the length of the record
+  - From that list, get the unique read lengths and their total count
+  - Order the counts in descending order
 requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
@@ -14,10 +18,8 @@ arguments:
     shellQuote: false
     valueFrom: >-
       $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c | sort -nr -k1,1 > $(inputs.input_bam.nameroot).bam_readlength
-
 inputs:
   input_bam: { type: File, doc: "Input bam file"}
-
 outputs:
   output:
     type: File

--- a/tools/samtools_readlength_bam.cwl
+++ b/tools/samtools_readlength_bam.cwl
@@ -2,7 +2,7 @@ cwlVersion: v1.2
 class: CommandLineTool
 id: samtools_readlength_bam
 doc: |-
-  samtools view file.bam | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c
+  samtools view file.bam | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c | sort -nr -k1,1
 requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
@@ -13,7 +13,7 @@ arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c > $(inputs.input_bam.nameroot).bam_readlength
+      $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c > $(inputs.input_bam.nameroot).bam_readlength | sort -nr -k1,1
 
 inputs:
   input_bam: { type: File, doc: "Input bam file"}

--- a/tools/samtools_readlength_bam.cwl
+++ b/tools/samtools_readlength_bam.cwl
@@ -1,0 +1,27 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: bam_readlength
+doc: |-
+  samtools view file.bam | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    coresMin: $(inputs.cores)
+  - class: DockerRequirement
+    dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
+baseCommand: [samtools,view]
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: >-
+      $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c > $(inputs.input_bam.nameroot).bam_readlength
+  
+inputs:
+  input_bam: { type: File, doc: "Input bam file"}
+
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "*.bam_readlength"

--- a/tools/samtools_readlength_bam.cwl
+++ b/tools/samtools_readlength_bam.cwl
@@ -13,7 +13,7 @@ arguments:
   - position: 1
     shellQuote: false
     valueFrom: >-
-      $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c > $(inputs.input_bam.nameroot).bam_readlength | sort -nr -k1,1
+      $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c | sort -nr -k1,1 > $(inputs.input_bam.nameroot).bam_readlength
 
 inputs:
   input_bam: { type: File, doc: "Input bam file"}

--- a/tools/samtools_readlength_bam.cwl
+++ b/tools/samtools_readlength_bam.cwl
@@ -1,13 +1,11 @@
 cwlVersion: v1.2
 class: CommandLineTool
-id: bam_readlength
+id: samtools_readlength_bam
 doc: |-
   samtools view file.bam | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c
 requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement
-  - class: ResourceRequirement
-    coresMin: $(inputs.cores)
   - class: DockerRequirement
     dockerPull: 'pgc-images.sbgenomics.com/d3b-bixu/samtools:1.9'
 baseCommand: [samtools,view]
@@ -16,7 +14,7 @@ arguments:
     shellQuote: false
     valueFrom: >-
       $(inputs.input_bam.path) | head -n 1000000 | cut -f 10 | perl -ne 'chomp;print length($_) . "\n"' | sort | uniq -c > $(inputs.input_bam.nameroot).bam_readlength
-  
+
 inputs:
   input_bam: { type: File, doc: "Input bam file"}
 
@@ -25,3 +23,23 @@ outputs:
     type: File
     outputBinding:
       glob: "*.bam_readlength"
+  top_readlength:
+    type: int
+    outputBinding:
+      glob: "*.bam_readlength"
+      loadContents: true
+      outputEval: |
+        ${
+          var rows = self[0].contents.split(/\r?\n/).slice(0,-1);
+          return rows[0].split(/\s/).pop();
+        }
+  variable_readlength:
+    type: boolean
+    outputBinding:
+      glob: "*.bam_readlength"
+      loadContents: true
+      outputEval: |
+        ${
+          var rows = self[0].contents.split(/\r?\n/).slice(0,-1);
+          return rows.length > 1;
+        }

--- a/tools/seqkit_readlength_fastq.cwl
+++ b/tools/seqkit_readlength_fastq.cwl
@@ -15,7 +15,7 @@ arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      seqkit fx2tab -nl $(inputs.input_fastq.path) | head -n 1000000 | cut -f 2 | sort | uniq -c > $(inputs.input_fastq.nameroot).fastq_readlength
+      seqkit fx2tab -nl $(inputs.input_fastq.path) | head -n 1000000 | cut -f 2 | sort | uniq -c > $(inputs.input_fastq.nameroot).fastq_readlength | sort -nr -k1,1
 
 inputs:
   input_fastq: { type: File, doc: "Input fastq file"}

--- a/tools/seqkit_readlength_fastq.cwl
+++ b/tools/seqkit_readlength_fastq.cwl
@@ -2,7 +2,11 @@ cwlVersion: v1.2
 class: CommandLineTool
 id: seqkit_readlength_fastq
 doc: |-
-  seqkit fx2tab -nl NA18152.fastq
+  Given a fastq input:
+  - Use seqkit + head to grab the first 1000000 records and convert that to a TSV
+  - Grab the column that contains the read length from the TSV (column 2)
+  - Get the unique read lengths as well as their counts
+  - Sort those read lengths by count in descending order
 requirements:
   - class: ShellCommandRequirement
   - class: InlineJavascriptRequirement

--- a/tools/seqkit_readlength_fastq.cwl
+++ b/tools/seqkit_readlength_fastq.cwl
@@ -15,7 +15,7 @@ arguments:
   - position: 0
     shellQuote: false
     valueFrom: >-
-      seqkit fx2tab -nl $(inputs.input_fastq.path) | head -n 1000000 | cut -f 2 | sort | uniq -c > $(inputs.input_fastq.nameroot).fastq_readlength | sort -nr -k1,1
+      seqkit fx2tab -nl $(inputs.input_fastq.path) | head -n 1000000 | cut -f 2 | sort | uniq -c | sort -nr -k1,1 > $(inputs.input_fastq.nameroot).fastq_readlength
 
 inputs:
   input_fastq: { type: File, doc: "Input fastq file"}

--- a/tools/seqkit_readlength_fastq.cwl
+++ b/tools/seqkit_readlength_fastq.cwl
@@ -9,7 +9,7 @@ requirements:
   - class: ResourceRequirement
     coresMin: $(inputs.cores)
   - class: DockerRequirement
-    dockerPull: zqs891011/seqkit:2.3.1
+    dockerPull: pgc-images.sbgenomics.com/d3b-bixu/seqkit:2.3.1
 baseCommand: []
 arguments:
   - position: 0

--- a/tools/seqkit_readlength_fastq.cwl
+++ b/tools/seqkit_readlength_fastq.cwl
@@ -1,0 +1,27 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: fastq_readlength
+doc: |-
+  seqkit fx2tab -nl NA18152.fastq
+requirements:
+  - class: ShellCommandRequirement
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    coresMin: $(inputs.cores)
+  - class: DockerRequirement
+    dockerPull: zqs891011/seqkit:2.3.1
+baseCommand: []
+arguments:
+  - position: 0
+    shellQuote: false
+    valueFrom: >-
+      seqkit fx2tab -nl $(inputs.input_fastq.path) | head -n 1000000 | cut -f 2 | sort | uniq -c > $(inputs.input_fastq.nameroot).fastq_readlength
+
+inputs:
+  input_fastq: { type: File, doc: "Input fastq file"}
+
+outputs:
+  output:
+    type: File
+    outputBinding:
+      glob: "*.fastq_readlength"

--- a/tools/seqkit_readlength_fastq.cwl
+++ b/tools/seqkit_readlength_fastq.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.2
 class: CommandLineTool
-id: fastq_readlength
+id: seqkit_readlength_fastq
 doc: |-
   seqkit fx2tab -nl NA18152.fastq
 requirements:
@@ -25,3 +25,23 @@ outputs:
     type: File
     outputBinding:
       glob: "*.fastq_readlength"
+  top_readlength:
+    type: int
+    outputBinding:
+      glob: "*.fastq_readlength"
+      loadContents: true
+      outputEval: |
+        ${
+          var rows = self[0].contents.split(/\r?\n/).slice(0,-1);
+          return rows[0].split(/\s/).pop();
+        }
+  variable_readlength:
+    type: boolean
+    outputBinding:
+      glob: "*.fastq_readlength"
+      loadContents: true
+      outputEval: |
+        ${
+          var rows = self[0].contents.split(/\r?\n/).slice(0,-1);
+          return rows.length > 1;
+        }

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -538,10 +538,10 @@ inputs:
       \ but only two files needed from that package", "sbg:suggestedValue": {class: 'File',
       path: '63cff818facdd82011c8d6fe', name: 'GRCh38_v39_fusion_annot_custom.tar.gz'}}
   # rmats
-  rmats_read_length: {type: 'int', doc: "Input read length for sample reads."}
+  rmats_read_length: {type: 'int?', doc: "Input read length for sample reads."}
   rmats_variable_read_length: {type: 'boolean?', doc: "Allow reads with lengths that\
       \ differ from --readLength to be processed. --readLength will still be used\
-      \ to determine IncFormLen and SkipFormLen.", default: true}
+      \ to determine IncFormLen and SkipFormLen."}
   rmats_novel_splice_sites: {type: 'boolean?', doc: "Select for novel splice site\
       \ detection or unannotated splice sites. 'true' to detect or add this parameter,\
       \ 'false' to disable denovo detection. Tool Default: false"}

--- a/workflow/rmats_wf.cwl
+++ b/workflow/rmats_wf.cwl
@@ -48,7 +48,7 @@ outputs:
   filtered_mutually_exclusive_exons_jc: {type: 'File', outputSource: filter_me_exons/output, doc: "Mutually exclusive exons JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
   filtered_retained_introns_jc: {type: 'File', outputSource: filter_retained_introns/output, doc: "Retained introns JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
   filtered_skipped_exons_jc: {type: 'File', outputSource: filter_skipped_exons/output, doc: "Skipped exons JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
-  unfiltered_results: { type: 'File[]', outputSource: [rmats_both_bam/alternative_3_prime_splice_sites_jc, rmats_both_bam/alternative_5_prime_splice_sites_jc, rmats_both_bam/mutually_exclusive_exons_jc, rmats_both_bam/retained_introns_jc, rmats_both_bam/skipped_exons_jc, rmats_both_bam/temp_read_outcomes, rmats_both_bam/summary_file] }
+  # unfiltered_results: { type: 'File[]', outputSource: [rmats_both_bam/alternative_3_prime_splice_sites_jc, rmats_both_bam/alternative_5_prime_splice_sites_jc, rmats_both_bam/mutually_exclusive_exons_jc, rmats_both_bam/retained_introns_jc, rmats_both_bam/skipped_exons_jc, rmats_both_bam/temp_read_outcomes, rmats_both_bam/summary_file] }
 
 steps:
   rmats_both_bam: 

--- a/workflow/rmats_wf.cwl
+++ b/workflow/rmats_wf.cwl
@@ -2,20 +2,50 @@ cwlVersion: v1.2
 class: Workflow
 id: rmats_wf
 label: "rMATS Turbo"
-doc: |-
-  # RMATS Workflow
+doc: |
+  # D3b rMATS Workflow
 
+  ## Introduction
+
+  The rMATS workflow can also be run as a standalone workflow. In this workflow, rMATS is run on the input BAM files to generate 5 junction files: `[alternative_3_prime_splice_sites_jc, alternative_5_prime_splice_sites_jc, mutually_exclusive_exons_jc, retained_introns_jc, skipped_exons_jc]`. The workflow next grabs the sample information from the `sample_1_bams` by parsing the read group information from the BAM header for use in the output names. Each of the five junction files then undergo a simple filtering process where calls that have junction counts less than 10 are removed. These filtered junction files are returned as the final outputs.
+
+  ## Usage
+
+  ### Inputs
+
+   - `gtf_annotation`: Input gtf annotation file
+   - `sample_1_bams:`: Input sample 1 bam files
+   - `sample_2_bams:`: Input sample 2 bam files
+   - `read_length:`: Input read length for sample reads
+   - `variable_read_length`: Allow reads with lengths that differ from --readLength to be processed. --readLength will still be used to determine IncFormLen and SkipFormLen
+   - `read_type`: Select one option for input read type either paired or single. Tool default: paired
+   - `strandedness`: Select one option for input strandedness. Tool default: fr-unstranded
+   - `novel_splice_sites:`: Select for novel splice site detection or unannotated splice sites. 'true' to detect or add this parameter, 'false' to disable denovo detection. Tool Default: false
+   - `stat_off:`: Select to skip statistical analysis, either between two groups or on single sample group. 'true' to add this parameter. Tool default: false
+   - `allow_clipping:`: Allow alignments with soft or hard clipping to be used
+   - `output_basename:`: String to use as basename for output files
+   - `rmats_threads:`: Threads to allocate to RMATs
+   - `rmats_ram:`: GB of RAM to allocate to RMATs
+
+  ### Outputs
+
+   - `filtered_alternative_3_prime_splice_sites_jc`: File extension `filtered.A3SS.MATS.JC.txt`. Alternative 3 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more junction spanning read counts of support
+   - `filtered_alternative_5_prime_splice_sites_jc`: File extension `filtered.A5SS.MATS.JC.txt`. Alternative 5 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more junction spanning read counts of support
+   - `filtered_mutually_exclusive_exons_jc`: File extension `filtered.MXE.MATS.JC.txt`. Mutually exclusive exons JC.txt output from RMATs containing only those calls with 10 or more junction spanning read counts of support
+   - `filtered_retained_introns_jc`: File extension `filtered.RI.MATS.JC.txt`. Retained introns JC.txt output from RMATs containing only those calls with 10 or more junction spanning read counts of support
+   - `filtered_skipped_exons_jc`: File extension `filtered.SE.MATS.JC.txt`. Skipped exons JC.txt output from RMATs containing only those calls with 10 or more junction spanning read counts of support
 requirements:
 - class: ScatterFeatureRequirement
 - class: StepInputExpressionRequirement
 - class: InlineJavascriptRequirement
-
 inputs:
-  gtf_annotation: { type: 'File', doc: "Input gtf annotation file." }
-  sample_1_bams: { type: 'File[]', doc: "Input sample 1 bam files." }
-  sample_2_bams: { type: 'File[]?', doc: "Input sample 2 bam files." }
-  read_length: { type: 'int', doc: "Input read length for sample reads." } 
-  variable_read_length: { type: 'boolean?', doc: "Allow reads with lengths that differ from --readLength to be processed. --readLength will still be used to determine IncFormLen and SkipFormLen." }
+  gtf_annotation: {type: 'File', doc: "Input gtf annotation file."}
+  sample_1_bams: {type: 'File[]', doc: "Input sample 1 bam files."}
+  sample_2_bams: {type: 'File[]?', doc: "Input sample 2 bam files."}
+  read_length: {type: 'int?', doc: "Input read length for sample reads."}
+  variable_read_length: {type: 'boolean?', doc: "Allow reads with lengths that differ\
+      \ from --readLength to be processed. --readLength will still be used to determine\
+      \ IncFormLen and SkipFormLen."}
   read_type:
     type:
     - "null"
@@ -24,41 +54,66 @@ inputs:
       - paired
       - single
       name: read_type
-    doc: "Select one option for input read type either paired or single. Tool default: paired"
+    doc: "Select one option for input read type either paired or single. Tool default:\
+      \ paired"
   strandedness:
     type:
     - "null"
     - type: enum
       symbols:
-        - fr-unstranded
-        - fr-firststrand
-        - fr-secondstrand
+      - fr-unstranded
+      - fr-firststrand
+      - fr-secondstrand
       name: strandedness
     doc: "Select one option for input strandedness. Tool default: fr-unstranded"
-  novel_splice_sites: { type: 'boolean?', doc: "Select for novel splice site detection or unannotated splice sites. 'true' to detect or add this parameter, 'false' to disable denovo detection. Tool Default: false" }
-  stat_off: { type: 'boolean?', doc: "Select to skip statistical analysis, either between two groups or on single sample group. 'true' to add this parameter. Tool default: false" }
-  allow_clipping: { type: 'boolean?', doc: "Allow alignments with soft or hard clipping to be used." }
-  output_basename: { type: 'string', doc: "String to use as basename for output files" }
-  rmats_threads: { type: 'int?', doc: "Threads to allocate to RMATs." }
-  rmats_ram: { type: 'int?', doc: "GB of RAM to allocate to RMATs." }
-
+  novel_splice_sites: {type: 'boolean?', doc: "Select for novel splice site detection\
+      \ or unannotated splice sites. 'true' to detect or add this parameter, 'false'\
+      \ to disable denovo detection. Tool Default: false"}
+  stat_off: {type: 'boolean?', doc: "Select to skip statistical analysis, either between\
+      \ two groups or on single sample group. 'true' to add this parameter. Tool default:\
+      \ false"}
+  allow_clipping: {type: 'boolean?', doc: "Allow alignments with soft or hard clipping\
+      \ to be used."}
+  output_basename: {type: 'string', doc: "String to use as basename for output files"}
+  rmats_threads: {type: 'int?', doc: "Threads to allocate to RMATs."}
+  rmats_ram: {type: 'int?', doc: "GB of RAM to allocate to RMATs."}
 outputs:
-  filtered_alternative_3_prime_splice_sites_jc: {type: 'File', outputSource: filter_alt_3_prime/output, doc: "Alternative 3 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
-  filtered_alternative_5_prime_splice_sites_jc: {type: 'File', outputSource: filter_alt_5_prime/output, doc: "Alternative 5 prime splice sites JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
-  filtered_mutually_exclusive_exons_jc: {type: 'File', outputSource: filter_me_exons/output, doc: "Mutually exclusive exons JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
-  filtered_retained_introns_jc: {type: 'File', outputSource: filter_retained_introns/output, doc: "Retained introns JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
-  filtered_skipped_exons_jc: {type: 'File', outputSource: filter_skipped_exons/output, doc: "Skipped exons JC.txt output from RMATs containing only those calls with 10 or more read counts of support" }
-  # unfiltered_results: { type: 'File[]', outputSource: [rmats_both_bam/alternative_3_prime_splice_sites_jc, rmats_both_bam/alternative_5_prime_splice_sites_jc, rmats_both_bam/mutually_exclusive_exons_jc, rmats_both_bam/retained_introns_jc, rmats_both_bam/skipped_exons_jc, rmats_both_bam/temp_read_outcomes, rmats_both_bam/summary_file] }
-
+  filtered_alternative_3_prime_splice_sites_jc: {type: 'File', outputSource: filter_alt_3_prime/output,
+    doc: "Alternative 3 prime splice sites JC.txt output from RMATs containing only\
+      \ those calls with 10 or more read counts of support"}
+  filtered_alternative_5_prime_splice_sites_jc: {type: 'File', outputSource: filter_alt_5_prime/output,
+    doc: "Alternative 5 prime splice sites JC.txt output from RMATs containing only\
+      \ those calls with 10 or more read counts of support"}
+  filtered_mutually_exclusive_exons_jc: {type: 'File', outputSource: filter_me_exons/output,
+    doc: "Mutually exclusive exons JC.txt output from RMATs containing only those\
+      \ calls with 10 or more read counts of support"}
+  filtered_retained_introns_jc: {type: 'File', outputSource: filter_retained_introns/output,
+    doc: "Retained introns JC.txt output from RMATs containing only those calls with\
+      \ 10 or more read counts of support"}
+  filtered_skipped_exons_jc: {type: 'File', outputSource: filter_skipped_exons/output,
+    doc: "Skipped exons JC.txt output from RMATs containing only those calls with\
+      \ 10 or more read counts of support"}
 steps:
-  rmats_both_bam: 
+  samtools_readlength_bam:
+    run: ../tools/samtools_readlength_bam.cwl
+    in:
+      input_bam:
+        source: sample_1_bams
+        valueFrom: |
+          $(self[0])
+    out: [output, top_readlength, variable_readlength]
+  rmats_both_bam:
     run: ../tools/rmats_both_bam.cwl
     in:
-      gtf_annotation: gtf_annotation 
-      sample_1: sample_1_bams 
+      gtf_annotation: gtf_annotation
+      sample_1: sample_1_bams
       sample_2: sample_2_bams
-      read_length: read_length
-      variable_read_length: variable_read_length
+      read_length:
+        source: [read_length, samtools_readlength_bam/top_readlength]
+        pickValue: first_non_null
+      variable_read_length:
+        source: [variable_read_length, samtools_readlength_bam/variable_readlength]
+        pickValue: first_non_null
       read_type: read_type
       strandedness: strandedness
       allow_clipping: allow_clipping
@@ -67,11 +122,13 @@ steps:
       output_directory: output_basename
       threads: rmats_threads
       ram: rmats_ram
-    out: [alternative_3_prime_splice_sites_jc, alternative_5_prime_splice_sites_jc, mutually_exclusive_exons_jc, retained_introns_jc, skipped_exons_jc, temp_read_outcomes, summary_file]
+    out: [alternative_3_prime_splice_sites_jc, alternative_5_prime_splice_sites_jc,
+      mutually_exclusive_exons_jc, retained_introns_jc, skipped_exons_jc, temp_read_outcomes,
+      summary_file]
   filter_alt_3_prime:
     run: ../tools/awk_junction_filtering.cwl
     in:
-      input_jc_file: rmats_both_bam/alternative_3_prime_splice_sites_jc 
+      input_jc_file: rmats_both_bam/alternative_3_prime_splice_sites_jc
     out: [output]
   filter_alt_5_prime:
     run: ../tools/awk_junction_filtering.cwl
@@ -93,3 +150,5 @@ steps:
     in:
       input_jc_file: rmats_both_bam/skipped_exons_jc
     out: [output]
+sbg:license: Apache License 2.0
+sbg:publisher: KFDRC


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

To ease the burden on OPs, we've introduced the following quality of life changes for the RNAseq workflow:
- rmats_read_length is no longer a required input
- rmats_variable_read_length no longer has a default value
- The rMATs workflow now has a tool that will poll the first 1000000 reads from the input bam and report the each read length observed as well as how many times that read length is observed. The tool will then report two values: first, the read length is defined as the read length that was most observed; second, if more than one read length is observed it will return variable read length as true.
- If the user wishes to override either of the values calculated by this tool, they can provide the values at workflow input. The workflow will always defer to user provided values and only use the calculated values when no user input is provided.

Closes https://github.com/d3b-center/bixu-tracker/issues/1864

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/d61ea502-b8a3-442d-83f3-5ee20d1d5a70/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
