### PR TITLE
🔧  allow t1k ram adjustment

### DIFF
--- a/tools/t1k.cwl
+++ b/tools/t1k.cwl
@@ -59,7 +59,7 @@ inputs:
   output_read_assignment: { type: 'boolean?', inputBinding: { position: 12 , prefix: "--outputReadAssignment" }, doc: "Set to output the allele assignment for each read to prefix_assign.tsv file" }
 
   threads: { type: 'int?', doc: "Num processing threads to use", default: 8, inputBinding: { position: 12, prefix: "-t" } }
-  ram: { type: 'int?', doc: "Num GB memory to make available", default: 16 }
+  ram: { type: 'int?', doc: "Num GB memory to make available", default: 32 }
 outputs:
   aligned_fasta: { type: 'File[]', outputBinding: { glob: '*_aligned_*.fa' } }
   allele_tsv: { type: File, outputBinding: { glob: '*_allele.tsv' } }

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -488,6 +488,7 @@ inputs:
   hla_rna_gene_coords: {type: 'File?', doc: "FASTA file containing the coordinates of the HLA genes for RNA.", "sbg:suggestedValue": {
       class: File, path: 6669ac8127374715fc3ba3c1, name: hla_v3.43.0_gencode_v39_rna_coord.fa}}
   t1k_abnormal_unmap_flag: {type: 'boolean?', doc: "Set if the flag in BAM for the unmapped read-pair is nonconcordant"}
+  t1k_ram: {type: 'int?', doc: "GB of RAM to allocate to T1k." }
 outputs:
   cutadapt_stats: {type: 'File?', outputSource: cutadapt_3-4/cutadapt_stats, doc: "Cutadapt stats output, only if adapter is supplied."}
   STAR_sorted_genomic_cram: {type: 'File', outputSource: samtools_bam_to_cram/output, doc: "STAR sorted and indexed genomic alignment
@@ -655,6 +656,7 @@ steps:
         valueFrom: $(self).t1k_hla
       skip_post_analysis:
         valueFrom: $(1 == 1)
+      ram: t1k_ram
     out: [genotype_tsv]
   bam_strandness:
     run: ../tools/bam_strandness.cwl


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

T1k was failing for some samples due to running out of RAM. This PR:
- Ups the default RAM to 32 since the failure rate due to RAM was about 50% at 16.
- Opens the RAM port to OPs should they need to adjust it beyond 32.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Failure due to too little ram: https://cavatica.sbgenomics.com/u/d3b-bixu-ops/sd-bhjxbdqk-organoid-rnaseq-analysis/tasks/e5348ddb-b983-44eb-b2f0-ecddaa57a120/#
- [x] Successful rerun with more ram: https://cavatica.sbgenomics.com/u/d3b-bixu-ops/sd-bhjxbdqk-organoid-rnaseq-analysis/tasks/4695bee4-1c98-4d0a-af8f-66650bb41bdc/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
