### PR TITLE
🐛  split reference optional

### DIFF
--- a/tools/samtools_split.cwl
+++ b/tools/samtools_split.cwl
@@ -23,7 +23,7 @@ requirements:
           set -xeo pipefail
           RG_NUM=`samtools head $(inputs.input_reads.path) | grep -c ^@RG`
           if [ $RG_NUM != 1 ]; then
-            samtools split -f '%*_%#.bam' -@ $(inputs.cores) --reference $(inputs.reference.path) $(inputs.input_reads.path)
+            samtools split -f '%*_%#.bam' -@ $(inputs.cores) $(inputs.reference ? '--reference ' + inputs.reference.path : '') $(inputs.input_reads.path)
           fi
 baseCommand: []
 arguments:
@@ -33,7 +33,7 @@ arguments:
       /bin/bash split_bam.sh
 inputs:
   input_reads: { type: File, doc: "Input bam file" }
-  reference: { type: File, doc: "Reference fasta file" }
+  reference: { type: 'File?', doc: "Reference fasta file" }
   ram: { type: 'int?', default: 36, doc: "GB of RAM to allocate to the task." }
   cpu: { type: 'int?', default: 36, doc: "Minimum reserved number of CPU cores for the task." }
 outputs:

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -835,5 +835,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v5.0.0'
+- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v5.0.1'
   label: github-release


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Makes the input reference optional for samtools split. Makes splitting of BAMs without a reference possible. 
Also bumped the version for a hotfix.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] BAM: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/955a3cfe-9bd5-4664-902d-1637bcc3ba61/
- [x] CRAM: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/7b4ec6f6-7e8c-4a5e-851f-4ddfad2304d0/

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
