### PR TITLE
🚑  rescue orphan reads

### DIFF
--- a/tools/samtools_split.cwl
+++ b/tools/samtools_split.cwl
@@ -22,7 +22,7 @@ requirements:
       - entryname: split_bam.sh
         entry: |-
           set -xeo pipefail
-          $(inputs.orphan_readgroup_text ? ["samtools addreplacerg -m orphan_only -o rg_rescue.bam", "--threads", inputs.cpu, "-r", inputs.orphan_readgroup_text, (inputs.reference ? "--reference " + inputs.reference.path : ""), inputs.input_reads.path].join(' ') : "echo 'Orphan ReadGroup Text Not Provided'")
+          $(inputs.orphan_readgroup_text ? ["samtools addreplacerg -m orphan_only -o rg_rescue.bam", "--threads", inputs.cpu, "-r", inputs.orphan_readgroup_text.replace(/\\t/g,"\\\\t"), (inputs.reference ? "--reference " + inputs.reference.path : ""), inputs.input_reads.path].join(' ') : "echo 'Orphan ReadGroup Text Not Provided'")
           RG_NUM=`samtools head $(inputs.orphan_readgroup_text ? "rg_rescue.bam" : inputs.input_reads.path) | grep -c ^@RG` || :
           if [ $RG_NUM = 0 ]; then
             echo "INPUT HAS NO READGROUPS! READGROUPS ARE REQUIRED FOR BAM INPUTS!"

--- a/tools/samtools_split.cwl
+++ b/tools/samtools_split.cwl
@@ -4,6 +4,7 @@ id: samtools_split
 doc: |-
   This tool splits the input bam input read group bams if it has more than one readgroup.
   Programs run in this tool:
+    - samtools addreplacerg
     - samtools head | grep
     - samtools split
   Using samtools view and grep count the header lines starting with @RG. If that number is
@@ -21,9 +22,13 @@ requirements:
       - entryname: split_bam.sh
         entry: |-
           set -xeo pipefail
-          RG_NUM=`samtools head $(inputs.input_reads.path) | grep -c ^@RG`
-          if [ $RG_NUM != 1 ]; then
-            samtools split -f '%*_%#.bam' -@ $(inputs.cores) $(inputs.reference ? '--reference ' + inputs.reference.path : '') $(inputs.input_reads.path)
+          $(inputs.orphan_readgroup_text ? ["samtools addreplacerg -m orphan_only -o rg_rescue.bam", "--threads", inputs.cpu, "-r", inputs.orphan_readgroup_text, (inputs.reference ? "--reference " + inputs.reference.path : ""), inputs.input_reads.path].join(' ') : "echo 'Orphan ReadGroup Text Not Provided'")
+          RG_NUM=`samtools head $(inputs.orphan_readgroup_text ? "rg_rescue.bam" : inputs.input_reads.path) | grep -c ^@RG` || :
+          if [ $RG_NUM = 0 ]; then
+            echo "INPUT HAS NO READGROUPS! READGROUPS ARE REQUIRED FOR BAM INPUTS!"
+            exit 1
+          elif [ $RG_NUM -gt 1 ]; then
+            samtools split -f '%*_%#.bam' -@ $(inputs.cpu) $(inputs.reference ? '--reference ' + inputs.reference.path : '') $(inputs.orphan_readgroup_text ? "rg_rescue.bam && rm rg_rescue.bam" : inputs.input_reads.path)
           fi
 baseCommand: []
 arguments:
@@ -34,8 +39,9 @@ arguments:
 inputs:
   input_reads: { type: File, doc: "Input bam file" }
   reference: { type: 'File?', doc: "Reference fasta file" }
-  ram: { type: 'int?', default: 36, doc: "GB of RAM to allocate to the task." }
-  cpu: { type: 'int?', default: 36, doc: "Minimum reserved number of CPU cores for the task." }
+  orphan_readgroup_text: { type: 'string?', doc: "@RG line text to use for orphan reads."}
+  ram: { type: 'int?', default: 16, doc: "GB of RAM to allocate to the task." }
+  cpu: { type: 'int?', default: 8, doc: "Minimum reserved number of CPU cores for the task." }
 outputs:
   bam_files:
     type: File[]

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -864,5 +864,5 @@ hints:
 - SE
 - STAR
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v5.0.2'
+- id: 'https://github.com/kids-first/kf-rnaseq-workflow/releases/tag/v5.1.0'
   label: github-release

--- a/workflow/kfdrc_RNAseq_workflow.cwl
+++ b/workflow/kfdrc_RNAseq_workflow.cwl
@@ -362,6 +362,7 @@ inputs:
   output_basename: {type: 'string?', doc: "String to use as basename for outputs. Will use read1 file basename if null"}
   input_alignment_files: {type: 'File[]?', secondaryFiles: [{"pattern": "^.bai", required: false}, {"pattern": ".bai", required: false},
       {"pattern": "^.crai", required: false}, {"pattern": ".crai", required: false}], doc: "List of input SAM/BAM/CRAM files to process"}
+  orphan_read_rescue_rg_str: {type: 'string?', doc: "RG string to use for reads in input_alignment_files with no assigned read group. If your input_alignment_files has zero read groups, processing will fail unless you provide a read group string here!"}
   input_pe_reads: {type: 'File[]?', doc: "List of R1 paired end FASTQ files to process"}
   input_pe_mates: {type: 'File[]?', doc: "List of R2 paired end FASTQ files to process"}
   input_se_reads: {type: 'File[]?', doc: "List of single end FASTQ files to process"}
@@ -556,6 +557,7 @@ steps:
     scatterMethod: dotproduct
     in:
       input_reads: input_alignment_files
+      orphan_readgroup_text: orphan_read_rescue_rg_str
       reference: cram_reference
     out: [bam_files]
   lists_to_reads_records:


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Adds a new field for users to specify a "rescue" read group for orphan reads (reads without a read group). It's not perfect because this read group is assigned to every alignment file input and will probably result in name collision down the line if people try to do this for multiple BAMs.

Addresses https://d3b.atlassian.net/browse/BIXU-4254

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Works locally with cwltool
- [x] Zero RG bam will still fail: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/846d8189-46fe-428c-8c49-c767ee3d2efd/
- [x] Rescue: https://cavatica.sbgenomics.com/u/kfdrc-harmonization/kf-reference-pipeline/tasks/8a308357-514b-4a3f-be12-969b7a0a6f2b/#

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have committed any related changes to the PR
